### PR TITLE
Prevent leaking of internal information to unprivileged users

### DIFF
--- a/sermon.php
+++ b/sermon.php
@@ -217,7 +217,7 @@ function sb_sermon_init () {
 		add_action('wp_head', 'wp_print_styles', 9);
 		add_action('admin_bar_menu', 'sb_admin_bar_menu', 45);
 		add_filter('wp_title', 'sb_page_title');
-		if (defined('SAVEQUERIES') && SAVEQUERIES)
+		if (defined('SAVEQUERIES') && SAVEQUERIES && defined('WP_DEBUG') && WP_DEBUG && is_user_logged_in() && current_user_can('manage_options'))
 			add_action ('wp_footer', 'sb_footer_stats');
 	} else {
 		require (SB_INCLUDES_DIR.'/admin.php');
@@ -225,7 +225,7 @@ function sb_sermon_init () {
 		add_action ('rightnow_end', 'sb_rightnow');
 		add_action('admin_init', 'sb_add_admin_headers');
 		add_filter('contextual_help', 'sb_add_contextual_help');
-		if (defined('SAVEQUERIES') && SAVEQUERIES)
+		if (defined('SAVEQUERIES') && SAVEQUERIES && defined('WP_DEBUG') && WP_DEBUG && current_user_can('manage_options'))
 			add_action('admin_footer', 'sb_footer_stats');
 	}
 }


### PR DESCRIPTION
Currently, if `SAVEQUERIES` is defined and true (e.g. you installed + activated http://wordpress.org/plugins/query-monitor/), then Sermon Browser will cause the output of information about all database queries (and file paths) in the HTML source, to all users. (I discovered this by examining my page cache files). As well as the information leakage, this was adding 680KB of size to the HTML source for me.

The mere presence of that constant is not sufficient to indicate that the site owner wishes debugging information to be made available to all visitors. The change in this branch restricts its display to logged-in + privileged users who have turned on debugging.